### PR TITLE
Fix Point2D.withPosition implementation

### DIFF
--- a/logic/model/point-2d.js
+++ b/logic/model/point-2d.js
@@ -280,17 +280,15 @@ Object.defineProperties(exports.Point2D, /** @lends Point2D */ {
         value: function (position, zoom) {
             var clip = exports.Point2D.clip,
                 max = exports.Point2D.MAX_LATITUDE,
-                mapSize = 256,
+                mapSize = 256 << (zoom || 0),
                 latitude = clip(position.latitude, -max, max),
                 longitude = clip(position.longitude, -180, 180),
                 x = (longitude + 180) / 360,
                 sinLatitude = Math.sin(latitude * Math.PI / 180),
                 y = 0.5 - Math.log((1 + sinLatitude) / (1 - sinLatitude)) / (4 * Math.PI),
-                pixelX = clip(x, 0, mapSize),
-                pixelY = clip(y, 0, mapSize),
-                point = exports.Point2D.withCoordinates(pixelX, pixelY);
-
-            return arguments.length === 1 ? point : point.multiply(mapSize << zoom);
+                pixelX = clip(Math.round(x * mapSize), 0, mapSize),
+                pixelY = clip(Math.round(y * mapSize), 0, mapSize);
+            return exports.Point2D.withCoordinates(pixelX, pixelY);
         }
     },
 

--- a/test/spec/point-2d.js
+++ b/test/spec/point-2d.js
@@ -1,4 +1,5 @@
-var Point2D = require("montage-geo/logic/model/point-2d").Point2D;
+var Point2D = require("montage-geo/logic/model/point-2d").Point2D,
+    Point = require("montage-geo/logic/model/point").Point;
 
 describe("Point 2D", function () {
 
@@ -96,4 +97,15 @@ describe("Point 2D", function () {
         expect(Math.abs(max.coordinates.latitude)).toBe(min.coordinates.latitude);
     });
 
+    it("can be converted from a position", function () {
+        var center = Point2D.withPosition(Point.withCoordinates(0, 0).coordinates),
+            min = Point2D.withPosition(Point.withCoordinates(-180, -90).coordinates),
+            max = Point2D.withPosition(Point.withCoordinates(180, 90).coordinates);
+        expect(center.x).toBe(128);
+        expect(center.y).toBe(128);
+        expect(min.x).toBe(0);
+        expect(min.y).toBe(256);
+        expect(max.x).toBe(256);
+        expect(max.y).toBe(0);
+    });
 });


### PR DESCRIPTION
The current implementation is untested and returns values in the range `[0, 1]` instead of `[0, 256 * 2^z]`, as is implied by the inverse function `toPoint`.

I'm not sure whether this code came from contour-framework, in which case it would have an impact there as well.